### PR TITLE
Allow 'Autoland' project tag next to using a hashtag in the commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3 - 2021-01-13
+
+- Allow "Autoland" project tag next to using a hashtag in the commit message
+
 ## 0.0.2 - 2020-11-26
 
 - Remove unnecessary permissions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phabricator-autoland",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Autoland Phabricator revisions which are ready to land",
   "main": "index.js",
   "scripts": {

--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -53,7 +53,10 @@ async function fetchDiffs() {
           [
             ...diffDoc.querySelectorAll(".phui-property-list-section-header"),
           ].filter((el) => el.innerText.toLowerCase().includes("summary"))[0]
-            ?.nextSibling?.innerText ?? "";
+            ?.nextSibling?.innerHTML ?? "";
+
+        const sideColumn =
+          diffDoc.querySelector(".phui-side-column").innerHTML || "";
 
         const { className: buildStatusClassName } = [
           ...diffDoc.querySelectorAll(".phui-status-list-view a"),
@@ -69,6 +72,12 @@ async function fetchDiffs() {
           ?.closest(".phui-box-border")
           .querySelector(".phui-oi-list-view .phui-oi-table-row");
 
+        const tag = phab.const.AUTOLAND_TAG;
+        const tagPath = `/tag/${phab.const.AUTOLAND_TAG.toLocaleLowerCase().replace(
+          "#",
+          ""
+        )}`;
+
         return {
           ...item,
           buildStatus: Object.entries({
@@ -81,7 +90,10 @@ async function fetchDiffs() {
             }
             return acc;
           }, "unknown"),
-          includesAutolandTag: summary.includes(phab.const.AUTOLAND_TAG),
+          includesAutolandTag:
+            summary.includes(tag) ||
+            summary.toLowerCase().includes(tagPath) ||
+            sideColumn.includes(tagPath),
           activeOperations: activeOperationsRow
             ? [
                 {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Phabricator Autoland",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "manifest_version": 2,
   "description": "Autoland Phabricator revisions which are ready to land",
   "background": {


### PR DESCRIPTION
Now works with:
* `#autoland` tag in the diff summary
![image](https://user-images.githubusercontent.com/127199/104486140-2fbca880-5580-11eb-9897-84cbaf90c079.png)

* Autoland project tag in the diff summary
![image](https://user-images.githubusercontent.com/127199/104486207-4531d280-5580-11eb-9d1a-241580e77981.png)

* Autoland project added as a tag to the diff
![image](https://user-images.githubusercontent.com/127199/104486094-20d5f600-5580-11eb-890b-4ce390d32a4e.png)

Thanks to @jparise for this recommendation